### PR TITLE
feat: Rename chatCmd to searchCmd and add word count flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Flags:
 ```
 
 >  eg: gencli search how big is google
+>  eg: gencli search what is kubernetes --words 525
 
 ### 📜 License
 

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -28,5 +28,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.AddCommand(chatCmd)
+	rootCmd.AddCommand(searchCmd)
+
 }

--- a/cmd/searchCmd.go
+++ b/cmd/searchCmd.go
@@ -38,8 +38,7 @@ func getApiRespone(args []string) string {
 	defer client.Close()
 
 	model := client.GenerativeModel("gemini-1.5-flash")
-	fmt.Println(userArgs+" in "+fmt.Sprint(numWords)+" words.")
-	resp, err := model.GenerateContent(ctx, genai.Text(userArgs+"in"+fmt.Sprint(numWords)+"words."))
+	resp, err := model.GenerateContent(ctx, genai.Text(userArgs+" in "+fmt.Sprint(numWords)+" words."))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/searchCmd.go
+++ b/cmd/searchCmd.go
@@ -12,7 +12,10 @@ import (
 	"google.golang.org/api/option"
 )
 
-var chatCmd = &cobra.Command{
+// response word count
+var numWords int = 150
+
+var searchCmd = &cobra.Command{
 	Use:   "search [your question]",
 	Short: "Ask a question and get a response",
 	Args:  cobra.MinimumNArgs(1),
@@ -24,7 +27,7 @@ var chatCmd = &cobra.Command{
 
 func getApiRespone(args []string) string {
 
-	userArgs := strings.Join(args[1:], " ")
+	userArgs := strings.Join(args[0:], " ")
 
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, option.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
@@ -35,7 +38,8 @@ func getApiRespone(args []string) string {
 	defer client.Close()
 
 	model := client.GenerativeModel("gemini-1.5-flash")
-	resp, err := model.GenerateContent(ctx, genai.Text(userArgs+"in 100-120 words."))
+	fmt.Println(userArgs+" in "+fmt.Sprint(numWords)+" words.")
+	resp, err := model.GenerateContent(ctx, genai.Text(userArgs+"in"+fmt.Sprint(numWords)+"words."))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,4 +47,8 @@ func getApiRespone(args []string) string {
 	finalResponse := resp.Candidates[0].Content.Parts[0]
 
 	return fmt.Sprint(finalResponse)
+}
+
+func init() {
+	searchCmd.Flags().IntVarP(&numWords, "words", "w", 150, "Specify the number of words in the response")
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Closes #4 

## 👨‍💻 Changes proposed

- Add a `-w` flag in the search command to specify the length of response/output in CLI.
- Chnage the `cmd/chatCmd.go` → `cmd/searchCmd.go` to match with the command name - `search`

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
