### PR TITLE
feat: add temperature and output file options to search command

### DIFF
--- a/cmd/searchCmd.go
+++ b/cmd/searchCmd.go
@@ -16,9 +16,9 @@ import (
 )
 
 var (
-	numWords       string  = "150"
-	outputLanguage string  = "english"
-	temperature    float32 = 0.7
+	numWords       string
+	outputLanguage string
+	temperature    float32
 	saveOutput     bool
 	outputFile     string
 )
@@ -46,7 +46,6 @@ var searchCmd = &cobra.Command{
 		} else {
 			fmt.Println(res)
 		}
-
 	},
 }
 
@@ -66,6 +65,7 @@ func getApiResponse(args []string) string {
 
 	currentGenaiModel := GetConfig("genai_model")
 	model := client.GenerativeModel(currentGenaiModel)
+	model.SetTemperature(temperature)
 	resp, err := model.GenerateContent(ctx, genai.Text(userArgs+" in "+numWords+" words"+" in "+outputLanguage+" language"))
 	CheckNilError(err)
 
@@ -101,7 +101,7 @@ func formatAsPlainText(input string) string {
 func init() {
 	searchCmd.Flags().StringVarP(&numWords, "words", "w", "150", "Number of words in the response")
 	searchCmd.Flags().StringVarP(&outputLanguage, "language", "l", "english", "Output language")
-	searchCmd.Flags().Float32VarP(&temperature, "temperature", "t", 0.7, "Response creativity (0.0-1.0)")
+	searchCmd.Flags().Float32VarP(&temperature, "temperature", "t", 0.5, "Response creativity (0.0-1.0)")
 	searchCmd.Flags().BoolVarP(&saveOutput, "save", "s", false, "Save the output to a file")
 	searchCmd.Flags().StringVarP(&outputFile, "output", "o", "output.txt", "Output file name")
 }

--- a/cmd/searchCmd.go
+++ b/cmd/searchCmd.go
@@ -19,7 +19,8 @@ var (
 	numWords       string  = "150"
 	outputLanguage string  = "english"
 	temperature    float32 = 0.7
-	outputFile     string  = ""
+	saveOutput     bool
+	outputFile     string
 )
 
 var searchCmd = &cobra.Command{
@@ -31,18 +32,24 @@ var searchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		res := getApiResponse(args)
 
-		if outputFile != "" {
-			dir := filepath.Dir(outputFile)
-			if dir != "." {
+		if saveOutput {
+			filename := outputFile
+			if filename == "" {
+				filename = "gencli-output.txt"
+			}
+
+			// Create directory if it doesn't exist
+			if dir := filepath.Dir(filename); dir != "." {
 				err := os.MkdirAll(dir, 0755)
 				CheckNilError(err)
 			}
-			err := os.WriteFile(outputFile, []byte(res), 0644)
-			CheckNilError(err)
-			fmt.Printf("Response saved to: %s\n", outputFile)
-		}
 
-		fmt.Println(res)
+			err := os.WriteFile(filename, []byte(res), 0644)
+			CheckNilError(err)
+			fmt.Printf("Response saved to: %s\n", filename)
+		} else {
+			fmt.Println(res)
+		}
 	},
 }
 
@@ -99,5 +106,6 @@ func init() {
 	searchCmd.Flags().StringVarP(&numWords, "words", "w", "150", "Number of words in the response")
 	searchCmd.Flags().StringVarP(&outputLanguage, "language", "l", "english", "Output language")
 	searchCmd.Flags().Float32VarP(&temperature, "temperature", "t", 0.7, "Response creativity (0.0-1.0)")
-	searchCmd.Flags().StringVarP(&outputFile, "save", "s", "", "Save response to file")
+	searchCmd.Flags().BoolVarP(&saveOutput, "save", "s", false, "Save response to file")
+	searchCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Specify output filename")
 }

--- a/cmd/versionCmd.go
+++ b/cmd/versionCmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CliVersion = "v1.6.3"
+const CliVersion = "v1.7.3"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
### Issue

Closes #22 


### 👨‍💻 Changes proposed
<!-- List all the proposed changes in your PR -->
- Added temperature control for response creativity
- Added save to file functionality
- Added new flags:
  - `--temperature` (`-t`): Controls response creativity (0.0-1.0)
  - `--save` (`-s`): Saves response to specified file

### ✔️ Check List
<!-- Mark with [x] to check the box -->
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [ ] I have updated the documentation accordingly.
- [x] Updated version of the `CliVersion` variable in `cmd/version.go` file.

### 📄 Note to reviewers
- Implementation follows existing code patterns
- Added error handling for file operations
- Temperature control allows finer tuning of AI responses
- File saving includes automatic directory creation
