### PR TITLE
feat: enhance image command with response saving and temperature control

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The above method sets the API key for the current session only. To set it perman
 
 #### Commands
 
+Below is the list of commands available in GenCLI:
+
 ```bash
 Usage:
   gencli [flags]
@@ -66,9 +68,26 @@ Flags:
   -h, --help   help for gencli
 ```
 
->  eg: gencli search "What is kubernetes" --words 525
->
->  eg: gencli image "What is this image about?" --path /path/to/image.jpg --format jpg
+An overview of subcommands with all the available options:
+
+```bash
+Usage:
+  gencli image [your question] --path [image path] --format [image format] [flags]
+
+Examples:
+gencli image 'What this image is about?' --path cat.png --format png
+
+Flags:
+  -f, --format string         Enter the image format (jpeg, png, etc.) (default "jpeg")
+  -h, --help                  help for image
+  -l, --language string       Enter the language for the output (default "english")
+  -o, --output string         Output file name (default "output.txt")
+  -p, --path string           Enter the image path
+  -s, --save                  Save the output to a file
+  -t, --temperature float32   Response creativity (0.0-1.0) (default 0.5)
+```
+
+This is for the `image` subcommand. Same goes for the `search` and other subcommands.
 
 ### 📜 License
 

--- a/cmd/imageCmd.go
+++ b/cmd/imageCmd.go
@@ -22,7 +22,7 @@ var (
 )
 
 var imageCmd = &cobra.Command{
-	Use:     "image [your question] --path [image path] --format [image format]",
+	Use:     "image [your question] --path [image path] --format [image format] --language [output language] --temperature [creativity] --save --output [output file]",
 	Example: "gencli image 'What this image is about?' --path cat.png --format png",
 	Short:   "Know details about an image (Please put your question in quotes)",
 	Long:    "Ask a question about an image and get a response. You need to provide the path of the image and the format of the image. The supported formats are jpg, jpeg, png, and gif.",

--- a/cmd/imageCmd.go
+++ b/cmd/imageCmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/generative-ai-go/genai"
@@ -12,9 +13,12 @@ import (
 )
 
 var (
-	imageFilePath       string
-	imageFileFormat     string
-	outputLanguageImage string
+	imageFilePath      string
+	imageFileFormat    string
+	respOutputLanguage string
+	saveResponse       bool
+	saveResponseFile   string
+	modelTemp          float32
 )
 
 var imageCmd = &cobra.Command{
@@ -24,12 +28,25 @@ var imageCmd = &cobra.Command{
 	Long:    "Ask a question about an image and get a response. You need to provide the path of the image and the format of the image. The supported formats are jpg, jpeg, png, and gif.",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		res := imageFunc(args)
-		fmt.Println(res)
+		res := getApiResponseImage(args)
+		if saveResponse {
+			// Create directory if it doesn't exist
+			dir := filepath.Dir(saveResponseFile)
+			if dir != "." {
+				err := os.MkdirAll(dir, 0755)
+				CheckNilError(err)
+			}
+
+			err := os.WriteFile(saveResponseFile, []byte(res), 0644)
+			CheckNilError(err)
+			fmt.Printf("Response saved to: %s\n", saveResponseFile)
+		} else {
+			fmt.Println(res)
+		}
 	},
 }
 
-func imageFunc(args []string) string {
+func getApiResponseImage(args []string) string {
 	userArgs := strings.Join(args[0:], " ")
 
 	ctx := context.Background()
@@ -46,7 +63,7 @@ func imageFunc(args []string) string {
 	// Supports multiple image inputs
 	prompt := []genai.Part{
 		genai.ImageData(imageFileFormat, imgData),
-		genai.Text(fmt.Sprintf(userArgs, " in ", outputLanguageImage, "language")),
+		genai.Text(fmt.Sprintf(userArgs, " in ", respOutputLanguage, " language")),
 	}
 
 	resp, err := model.GenerateContent(ctx, prompt...)
@@ -59,12 +76,11 @@ func imageFunc(args []string) string {
 
 func init() {
 	imageCmd.Flags().StringVarP(&imageFilePath, "path", "p", "", "Enter the image path")
-	imageCmd.Flags().StringVarP(&imageFileFormat, "format", "f", "", "Enter the image format (jpeg, png, etc.)")
-	imageCmd.Flags().StringVarP(&outputLanguageImage, "language", "l", "english", "Enter the language for the output")
+	imageCmd.Flags().StringVarP(&imageFileFormat, "format", "f", "jpeg", "Enter the image format (jpeg, png, etc.)")
+	imageCmd.Flags().StringVarP(&respOutputLanguage, "language", "l", "english", "Enter the language for the output")
+	imageCmd.Flags().Float32VarP(&modelTemp, "temperature", "t", 0.5, "Response creativity (0.0-1.0)")
+	imageCmd.Flags().BoolVarP(&saveResponse, "save", "s", false, "Save the output to a file")
+	imageCmd.Flags().StringVarP(&saveResponseFile, "output", "o", "output.txt", "Output file name")
 	errPathF := imageCmd.MarkFlagRequired("path")
-	errFormatF := imageCmd.MarkFlagRequired("format")
-	errLanguageF := imageCmd.MarkFlagRequired("language")
 	CheckNilError(errPathF)
-	CheckNilError(errFormatF)
-	CheckNilError(errLanguageF)
 }

--- a/cmd/versionCmd.go
+++ b/cmd/versionCmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CliVersion = "v1.6.3"
+const CliVersion = "v1.8.3"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
### 🛠️ Fixes Issue <!-- Remove this section if not applicable -->

Closes #24 

### 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->

- fix: sub-command image `format` and `language` flags  not required–those are optional and have a default value that it can fall back to
- feat: add the `--save` option to the command to save the response in a file. Just like #22 
- feat: add `--temperature` flag to set the temp of the model.


- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [x] I have updated the documentation accordingly (if required).
- [ ] Update the version of the `CliVersion` variable in `cmd/version.go` file (if there is a version change).

### 📄 Note to reviewers <!-- Add notes to reviewers if applicable -->


### 📷 Screenshots <!-- Remove this section if not applicable -->
