### PR TITLE
feat: update GenAI model options and default model to Gemini 2.0 Flash

### DIFF
--- a/cmd/changeModelCmd.go
+++ b/cmd/changeModelCmd.go
@@ -22,7 +22,7 @@ func setModelConfig() {
 	currentGenaiModel := GetConfigFunc("genai_model")
 	fmt.Println("Current model:", currentGenaiModel)
 
-	options := []string{"Gemini 2.0 Flash", "Gemini 2.0 Flash-Lite Preview", "Gemini 1.5 Flash", "Gemini 1.5 Flash-8B", "Gemini 1.5 Pro"}
+	options := []string{"Gemini 2.5 Flash Preview 04-17", "Gemini 2.0 Flash", "Gemini 2.0 Flash-Lite Preview"}
 
 	var selected string
 	prompt := &survey.Select{
@@ -34,18 +34,14 @@ func setModelConfig() {
 	CheckNilError(err)
 
 	switch selected {
+	case "Gemini 2.5 Flash Preview 04-17":
+		selected = "gemini-2.5-flash-preview-04-17"
 	case "Gemini 2.0 Flash":
 		selected = "gemini-2.0-flash"
 	case "Gemini 2.0 Flash-Lite Preview":
-		selected = "gemini-2.0-flash-lite-preview"
-	case "Gemini 1.5 Flash":
-		selected = "gemini-1.5-flash"
-	case "Gemini 1.5 Flash-8B":
-		selected = "gemini-1.5-flash-8b"
-	case "Gemini 1.5 Pro":
-		selected = "gemini-1.5-pro"
+		selected = "gemini-2.0-flash-lite"
 	default:
-		selected = "gemini-1.5-flash"
+		selected = "gemini-2.0-flash"
 	}
 	UpdateConfigFunc("genai_model", selected)
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -316,16 +316,16 @@ func TestModelCommand(t *testing.T) {
 			expectedMessage: "Model updated to: gemini-2.0-flash",
 		},
 		{
-			name:            "select_gemini_1.5_pro",
-			mockSelection:   "Gemini 1.5 Pro",
-			expectedModel:   "gemini-1.5-pro",
-			expectedMessage: "Model updated to: gemini-1.5-pro",
+			name:            "select_gemini_2.0_flash_lite",
+			mockSelection:   "Gemini 2.0 Flash-Lite Preview",
+			expectedModel:   "gemini-2.0-flash-lite",
+			expectedMessage: "Model updated to: gemini-2.0-flash-lite",
 		},
 		{
 			name:            "invalid_selection_default",
 			mockSelection:   "Invalid Model",
-			expectedModel:   "gemini-1.5-flash", // Default model in case of an invalid selection.
-			expectedMessage: "Model updated to: gemini-1.5-flash",
+			expectedModel:   "gemini-2.0-flash", // Default model in case of an invalid selection.
+			expectedMessage: "Model updated to: gemini-2.0-flash",
 		},
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -12,7 +12,7 @@ var (
 	configFileDir  string = ".gencli"
 	configFileName string = "config"
 	configFileType string = "yaml"
-	defaultModel   string = "gemini-1.5-flash"
+	defaultModel   string = "gemini-2.0-flash"
 )
 
 func SetDefaultConfig() {

--- a/cmd/versionCmd.go
+++ b/cmd/versionCmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CliVersion = "v1.8.3"
+const CliVersion = "v1.8.4"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
### Changes proposed

- Update the default model to 2.0 flash
- Deprecated the 1.5 series model
- Added 2.5 Flash preview model

### Checklist
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [x] I have updated the documentation accordingly (if required).
- [x] Update the version of the `CliVersion` variable in `cmd/version.go` file (if there is a version change).


