### PR TITLE
fix: repair the release workflow (go version + goreleaser v2 config)

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version-file: go.mod
           cache: false
 
       - name: Run GoReleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -24,12 +24,12 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        formats: [zip]
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   # filters:


### PR DESCRIPTION
The GoReleaser release on `main` failed after the dependency upgrade. Two causes:

1. **Go version**: the release job pinned `go-version: 1.23`, but the upgraded `go.mod` requires `go 1.25`, so the `go mod tidy` before-hook failed (`GOTOOLCHAIN=local`). Now reads `go-version-file: go.mod`.
2. **GoReleaser v2 config**: `goreleaser-action` was bumped to v7 (GoReleaser v2), which deprecated some fields. Updated `.goreleaser.yaml`:
   - `archives.format: tar.gz` → `archives.formats: [tar.gz]`
   - `format_overrides[].format: zip` → `formats: [zip]`
   - `snapshot.name_template` → `snapshot.version_template`

## Verification
- `goreleaser check` passes with no deprecations/errors