### PR TITLE
fix: correct image command prompt construction

### DIFF
--- a/cmd/imageCmd.go
+++ b/cmd/imageCmd.go
@@ -66,7 +66,7 @@ func imageFunc(args []string) string {
 	// Supports image + text input
 	parts := []*genai.Part{
 		genai.NewPartFromBytes(imgData, "image/"+imageFileFormat),
-		genai.NewPartFromText(fmt.Sprintf(userArgs, " in ", respOutputLanguage, " language")),
+		genai.NewPartFromText(userArgs + " in " + respOutputLanguage + " language"),
 	}
 	contents := []*genai.Content{genai.NewContentFromParts(parts, genai.RoleUser)}
 


### PR DESCRIPTION
The `image` command built its prompt with `fmt.Sprintf(userArgs, " in ", respOutputLanguage, " language")`, passing the user's question as a **format string**. With no verbs in it, Go appended a garbage suffix, e.g.:

`What is in this image%!(EXTRA string= in , string=english, string= language)`

Fixed to plain concatenation (matching the `search` command): `userArgs + " in " + respOutputLanguage + " language"`.

## Verification
- build, vet, golangci-lint, test all pass
- `gencli image` verified end-to-end against the live API (correctly returned "Green" for a green image)